### PR TITLE
画像の一覧、削除、登録を別ページへ

### DIFF
--- a/flask_app/models.py
+++ b/flask_app/models.py
@@ -19,5 +19,19 @@ class Image(db.Model):
         db.session.commit()
 
     @classmethod
+    def delete(cls, file_name):
+        if file_name:
+            db.session.query(cls).filter(cls.file_name == file_name).delete()
+            db.session.commit()
+
+    @classmethod
     def get_all_images_by_label(cls, label_name):
         return cls.query.filter(cls.label.like(f"%{label_name}%")).all()
+
+    @classmethod
+    def get_all_images(cls):
+        return cls.query.all()
+
+    @classmethod
+    def count_images(cls):
+        return cls.query.count()

--- a/flask_app/models.py
+++ b/flask_app/models.py
@@ -4,7 +4,7 @@ from sqlalchemy import Column, Integer, String
 class Image(db.Model):
     __tablename__ = 'images'
     id = db.Column(db.Integer, primary_key=True)
-    file_name = db.Column(db.String)
+    file_name = db.Column(db.String, unique=True)
     label = db.Column(db.String)
 
     def __init__(self, file_name, label):
@@ -35,3 +35,7 @@ class Image(db.Model):
     @classmethod
     def count_images(cls):
         return cls.query.count()
+
+    @classmethod
+    def isInSameName(cls, file_name):
+        return cls.query.filter(cls.file_name == file_name).count() > 0

--- a/flask_app/templates/image_chat.index.html
+++ b/flask_app/templates/image_chat.index.html
@@ -7,12 +7,9 @@
 			<!-- chat will be displayed here -->
 	</div>
 	<div class="chat-form-container fixed-bottom text-center">
-			<div class="d-flex mx-auto mb-4 align-items-center" style="width: 80%;">
-						<div class="input-group me-2" style="width: 40%;">
-							<input type="file" id="image-input" accept="image/*" class="form-control">
-							<button class="btn btn-success" type="submit" id="image-upload-button">
-								<i class="bi bi-upload"></i> Upload
-							</button>
+			<div class="d-flex mx-auto mb-4 align-items-center justify-content-center" style="width: 80%;">
+						<div style="width: 10%;">
+							<a href="{{ url_for('image_chat.list') }}" class="btn btn-primary mx-2" ><i class="bi bi-images"></i> Images</a>
 						</div>
 						<div class="input-group"  style="width: 60%;">
 							<textarea id="chat-input" class="form-control" placeholder="Type a message..." rows="1"></textarea>
@@ -22,7 +19,7 @@
 						</div>
 			</div>
 			<div class="chat-instructions text-center w-50 mx-auto mb-1">
-					Click Button to Upload Image / Shift + Enter or Click Send button to send a message
+					Shift + Enter or Click Send button to send a message
 			</div>
 	</div>
 </div>
@@ -66,30 +63,6 @@
 			height: 150px;
 	}
 </style>
-
-<script>
-	document.getElementById('image-upload-button').addEventListener('click', function(e) {
-		e.preventDefault();
-    const imageInput = document.getElementById('image-input');
-		if (imageInput.files.length === 0) {
-			alert("Please select an image file.");
-			return;
-		}
-		const formData = new FormData();
-		formData.append('image-input', imageInput.files[0]);
-		fetch('/upload_image', {
-			method: 'POST',
-			body: formData
-		})
-		.then(response => response.text())
-		.then(data => {
-					imageInput.value = '';
-					alert("Uploaded Image Successfully!");
-			})
-			.catch(error => console.error('Error:', error));
-	});
-	</script>
-
 
 <script>
 	document.getElementById('chat-input').addEventListener('keydown', function(e) {

--- a/flask_app/templates/image_chat.index.html
+++ b/flask_app/templates/image_chat.index.html
@@ -118,7 +118,6 @@
 		.then(data => {
 			const botMessage = document.createElement('div');
 			botMessage.classList.add('mb-1', 'bot-message');
-			// TODO : 画像を表示する
 			botMessage.innerHTML = `<p><img src="{{ url_for('static', filename='images/penguin.png') }}" alt="Bot" class="image-size"> <strong>Bot</strong></p><pre>`;
 			data.forEach(function(item, index) {
 				botMessage.innerHTML += `<img src="/static/uploads/${item}" alt="Bot" class="response-image">`;

--- a/flask_app/templates/image_chat.list.html
+++ b/flask_app/templates/image_chat.list.html
@@ -1,0 +1,96 @@
+{% extends "layout.html" %}
+
+{% block body %}
+
+<div class="container  flex-column justify-content-center align-items-center">
+	<div id="image-box" class="mt-3 w-100">
+		<div class="row">
+			{% for image in images %}
+				<div class="col mb-4">
+					<img src="{{ url_for('static', filename='uploads/' + image.file_name) }}" class="response-image mb-2">
+					<form id="deleteForm" action="{{ url_for('image_chat.delete', file_name=image.file_name) }}" method="post">
+						<button type="submit" class="btn btn-danger btn-sm" onclick="return confirmDelete()">Delete</button>
+				</form>
+				</div>
+			{% endfor %}
+		</div>
+	</div>
+	<div class="chat-form-container fixed-bottom text-center">
+		<div class="d-flex mx-auto mb-4 align-items-center" style="width: 60%;">
+						<div style="width: 10%;">
+							<a href="{{ url_for('image_chat.chat') }}" class="btn btn-secondary mx-2" ><i class="bi bi-arrow-left"></i> Back</a>
+						</div>
+						<div class="input-group" style="width: 80%;">
+							<input type="file" id="image-input" accept="image/*" class="form-control">
+							<button class="btn btn-success" type="submit" id="image-upload-button">
+								<i class="bi bi-upload"></i> Upload
+							</button>
+						</div>
+		</div>
+		<div class="chat-instructions text-center w-50 mx-auto mb-1">
+					Click Button to Upload Image
+		</div>
+	</div>
+</div>
+
+
+
+<style>
+	#image-box {
+    max-height: 700px;
+    overflow-y: auto;
+}
+	.chat-instructions {
+			color: #999;
+			font-size: 12px;
+	}
+	pre {
+			white-space: pre-wrap;
+			word-wrap: break-word;
+	}
+	.image-size {
+			width: 1.5em;
+			height: 1.5em;
+	}
+	.response-image {
+			width: 300px;
+			height: 300px;
+	}
+</style>
+
+<script>
+	function confirmDelete() {
+			if (confirm("Are you sure ? This action cannot be undone.")) {
+					return true;
+			} else {
+					return false;
+			}
+	}
+	</script>
+
+<script>
+	document.getElementById('image-upload-button').addEventListener('click', function(e) {
+		e.preventDefault();
+    const imageInput = document.getElementById('image-input');
+		if (imageInput.files.length === 0) {
+			alert("Please select an image file.");
+			return;
+		}
+		const formData = new FormData();
+		formData.append('image-input', imageInput.files[0]);
+		fetch('/upload_image', {
+			method: 'POST',
+			body: formData
+		})
+		.then(response => response.text())
+		.then(data => {
+					imageInput.value = '';
+					alert("Uploaded Image Successfully!");
+					window.location.reload();
+			})
+			.catch(error => console.error('Error:', error));
+	});
+	</script>
+
+
+{% endblock %}

--- a/flask_app/templates/image_chat.list.html
+++ b/flask_app/templates/image_chat.list.html
@@ -82,13 +82,21 @@
 			method: 'POST',
 			body: formData
 		})
-		.then(response => response.text())
+		.then(response => {
+			if (response.ok) {
+				return response.json();
+			} else {
+				throw new Error("Same File Name Exists.");
+			}
+		})
 		.then(data => {
 					imageInput.value = '';
 					alert("Uploaded Image Successfully!");
 					window.location.reload();
+					const imageBox = document.getElementById('image-box');
+					imageBox.scrollTop = imageBox.scroll
 			})
-			.catch(error => console.error('Error:', error));
+			.catch(error => {alert("Error: " + error.message)});
 	});
 	</script>
 

--- a/flask_app/templates/layout.html
+++ b/flask_app/templates/layout.html
@@ -33,7 +33,9 @@
 					{% elif request.path == url_for('feedback.feedback') %}
 							<span style="color: #fff; text-decoration: underline solid #ccc auto;"><i class="bi bi-clipboard-check"></i> Feedback</span>
 					{% elif request.path == url_for('image_chat.chat') %}
-							<span style="color: #fff; text-decoration: underline solid #ccc auto;"><i class="bi bi-image"></i> Image Search</span>
+							<span style="color: #fff; text-decoration: underline solid #ccc auto;"><i class="bi bi-search"></i> Image Search</span>
+					{% elif request.path == url_for('image_chat.list') %}
+							<span style="color: #fff; text-decoration: underline solid #ccc auto;"><i class="bi bi-images"></i> Images List</span>
 					{% elif request.path == url_for('manual.manual') %}
 							<span style="color: #fff; text-decoration: underline solid #ccc auto;"><i class="bi bi-question-circle"></i> Manual</span>
 					{% endif %}
@@ -48,8 +50,6 @@
 					</div>
 					<div class="offcanvas-body">
 						<ul class="navbar-nav justify-content-end flex-grow-1 pe-3">
-							<!-- TODO : activeに付いて設定 -->
-							<!-- TODO : hrefにurl_forを使う -->
 							<li class="nav-item">
 								<a class="nav-link {{ 'active' if request.path == url_for('home') else '' }}" aria-current="page" href="{{url_for('home')}}"><i class="bi bi-house-door-fill"></i> Home</a>
 							</li>
@@ -60,7 +60,12 @@
 								<a class="nav-link {{ 'active' if request.path == url_for('feedback.feedback') else '' }}" href="{{url_for('feedback.feedback')}}"><i class="bi bi-clipboard-check"></i> Feedback (implementing)</a>
 							</li>
 							<li class="nav-item">
-								<a class="nav-link {{ 'active' if request.path == url_for('image_chat.chat') else '' }}" href="{{url_for('image_chat.chat')}}"><i class="bi bi-image"></i> Image Search</a>
+								<a class="nav-link {{ 'active' if request.path == url_for('image_chat.chat') else '' }}" href="{{url_for('image_chat.chat')}}"><i class="bi bi-search"></i> Image Search</a>
+								<ul class="list-unstyled ms-4">
+									<li class="nav-item">
+											<a class="nav-link {{ 'active' if request.path == url_for('image_chat.list') else '' }}" href="{{url_for('image_chat.list')}}"><i class="bi bi-images"></i> Images List</a>
+									</li>
+							</ul>
 							</li>
 							<li class="nav-item">
 								<a class="nav-link {{ 'active' if request.path == url_for('manual.manual') else '' }}" href="{{url_for('manual.manual')}}"><i class="bi bi-question-circle"></i> Manual</a>

--- a/flask_app/templates/manual.index.html
+++ b/flask_app/templates/manual.index.html
@@ -61,7 +61,7 @@
     </section>
     <hr>
     <section id="features" class="mt-2">
-        <h2 class="text-center"><i class="bi bi-image"></i> Image Search</h2><br>
+        <h2 class="text-center"><i class="bi bi-images"></i> Image Search</h2><br>
         <h4>Features</h4>
         <p>
             <ul>

--- a/flask_app/views/image_chat.py
+++ b/flask_app/views/image_chat.py
@@ -77,6 +77,9 @@ def upload_image():
 
     if file and file.filename != '':
         new_image = Image(file_name=file.filename, label=get_label(file.read()))
+        if Image.isInSameName(file.filename):
+            current_app.logger.warning("Same file name exists")
+            return jsonify({"error": "Same file name exists"}), 400
         file_path = os.path.join(current_app.config['UPLOAD_FILE_PATH'], file.filename)
         new_image.register()
         file.seek(0)

--- a/flask_app/views/image_chat.py
+++ b/flask_app/views/image_chat.py
@@ -48,6 +48,21 @@ def get_word_list(user_message):
     word_list = responce.split(",")
     return word_list
 
+@image_chat_bp.route('/image_chat/list', methods=['GET'])
+def list():
+    images = Image.get_all_images()
+    return render_template('image_chat.list.html', images=images)
+
+@image_chat_bp.route('/image_chat/delete', methods=['POST'])
+def delete():
+    query = ""
+    query = request.args.get('file_name')
+    print(query)
+    if query:
+        Image.delete(query)
+        os.remove(os.path.join(current_app.config['UPLOAD_FILE_PATH'], query))
+        current_app.logger.info("Delete " + query + " from database and file system successfully.")
+    return redirect(url_for('image_chat.list'))
 
 @image_chat_bp.route('/image_chat')
 def chat():
@@ -56,6 +71,7 @@ def chat():
 @image_chat_bp.route('/upload_image', methods=['POST'])
 def upload_image():
     if 'image-input' not in request.files:
+        current_app.logger.warning("No file part")
         return redirect(request.url)
     file = request.files['image-input']
 
@@ -65,7 +81,8 @@ def upload_image():
         new_image.register()
         file.seek(0)
         file.save(file_path)
-        return redirect(url_for('image_chat.chat'))
+        current_app.logger.info("Save " + file.filename + " to database and file system successfully.")
+        return redirect(url_for('image_chat.list'))
     return redirect(request.url)
 
 @image_chat_bp.route('/image_chat/send_message', methods=['POST'])


### PR DESCRIPTION
### 実装したこと
- 画像の一覧、削除、登録を別ページに移した
- それによるその他フロントの修正


### 遷移
- 画像検索欄の左側のボタンから遷移、戻るボタンも用意
- また、メニューバーからも遷移できるようにしてある

### テスト
- 同一名の画像は投稿できないようにした
- 削除前にconfirmが出るようにした

![スクリーンショット 2024-01-19 22 10 16](https://github.com/ryhara/Azure_OpenAI_Service_Hackathon/assets/89718149/9691ef88-019b-4da5-9a2a-de9119d1176d)

![スクリーンショット 2024-01-19 22 10 25](https://github.com/ryhara/Azure_OpenAI_Service_Hackathon/assets/89718149/7fd98a4e-e6e1-40a9-8ae4-ebd0f5a20963)

確認したらマージしてOKです。

