### PR TITLE
GPT3-5, 4を選択できるように修正

### DIFF
--- a/flask_app/templates/feedback.index.html
+++ b/flask_app/templates/feedback.index.html
@@ -2,22 +2,31 @@
 
 {% block body %}
 
-<div class="container d-flex flex-column justify-content-center align-items-center">
+<div class="container d-flex flex-column justify-content-center align-items-center h-100">
 	<div id="chat-box" class="mt-3 w-75">
 			<!-- chat will be displayed here -->
 	</div>
-	<div class="chat-form-container fixed-bottom text-center">
-		<form id="chat-form" class="input-group mb-4" style="margin-left: 20vw; width: 70%;">
-			<label class="input-group-text" for="pdf-input">
-				<i class="bi bi-filetype-pdf"></i>
-			</label>
-			<input type="file" id="pdf-input" accept="application/pdf" class="form-control" style="display: none;">
-			<textarea id="chat-input" class="form-control" placeholder="Type a message..." rows="1"></textarea>
-			<button type="submit" class="btn btn-dark">
+	<div class="chat-form-container text-center w-100 flex-grow-1 d-flex flex-column justify-content-end">
+		<div class="d-flex justify-content-between align-items-end w-100" >
+			<form id="chat-form" class="input-group mb-4" style="width: 60%; margin-left: 20vw;">
+				<label class="input-group-text" for="pdf-input">
+					<i class="bi bi-filetype-pdf"></i>
+				</label>
+				<input type="file" id="pdf-input" accept="application/pdf" class="form-control" style="display: none;">
+				<textarea id="chat-input" class="form-control" placeholder="Type a message..." rows="1"></textarea>
+				<button type="submit" class="btn btn-dark">
 					<i class="bi bi-send-fill"></i>
-			</button>
-		</form>
-		<div class="chat-instructions text-center w-50 mx-auto mb-1">
+				</button>
+			</form>
+		</div>
+		<div class="btn-group chat-options ms-auto me-4 mb-4 fixed-bottom " role="group" aria-label="gpt" style="width: 10%;">
+			<input type="radio" class="btn-check" name="chat-option" value="gpt-3-5" id="btnradio1" autocomplete="off" checked>
+			<label class="btn btn-outline-primary" for="btnradio1">GPT-3.5</label>
+
+			<input type="radio" class="btn-check" name="chat-option" value="/gpt-4" id="btnradio2" autocomplete="off">
+			<label class="btn btn-outline-primary" for="btnradio2">GPT-4</label>
+		</div>
+		<div class="chat-instructions text-center w-50 mx-auto mb-1 fixed-bottom">
 				Shift + Enter or Click button to send a message
 		</div>
 	</div>

--- a/flask_app/templates/feedback.index.html
+++ b/flask_app/templates/feedback.index.html
@@ -134,7 +134,9 @@
 			userMessage.innerHTML = `<p class="text-primary-emphasis"><i class="bi bi-person-fill"></i> <strong>User</strong></p><pre>${escapeHtml(message)}</pre>`;
 		}
 		chatBox.appendChild(userMessage);
-    fetch('/feedback/send_message', {
+		const selectedOption = document.querySelector('input[name="chat-option"]:checked').value;
+		const postUrl = selectedOption === 'gpt-3-5' ? '/feedback/send_message/gpt-3-5' : '/feedback/send_message/gpt-4';
+    fetch(postUrl, {
         method: 'POST',
         body: formData
     })

--- a/flask_app/templates/image_chat.index.html
+++ b/flask_app/templates/image_chat.index.html
@@ -9,7 +9,7 @@
 	<div class="chat-form-container text-center w-100 flex-grow-1 d-flex flex-column justify-content-end">
 			<div class="d-flex mb-4 align-items-center justify-content-center" style="width: 100%;">
 						<div style="width: 10%;">
-							<a href="{{ url_for('image_chat.list') }}" class="btn btn-primary mx-2" ><i class="bi bi-images"></i> Images</a>
+							<a href="{{ url_for('image_chat.list') }}" class="btn btn-secondary me-4 btn-sm" ><i class="bi bi-images"></i> Images</a>
 						</div>
 						<div class="input-group"  style="width: 60%;">
 							<textarea id="chat-input" class="form-control" placeholder="Type a message..." rows="1"></textarea>
@@ -17,6 +17,13 @@
 									<i class="bi bi-send-fill"></i>
 							</button>
 						</div>
+						<div class="btn-group chat-options ms-4" role="group" aria-label="gpt">
+							<input type="radio" class="btn-check" name="chat-option" value="gpt-3-5" id="btnradio1" autocomplete="off" checked>
+							<label class="btn btn-outline-primary" for="btnradio1">GPT-3.5</label>
+
+							<input type="radio" class="btn-check" name="chat-option" value="/gpt-4" id="btnradio2" autocomplete="off">
+							<label class="btn btn-outline-primary" for="btnradio2">GPT-4</label>
+					</div>
 			</div>
 			<div class="chat-instructions text-center w-50 mx-auto mb-1">
 					Shift + Enter or Click Send button to send a message

--- a/flask_app/templates/image_chat.index.html
+++ b/flask_app/templates/image_chat.index.html
@@ -116,12 +116,17 @@
 		const userMessage = document.createElement('div');
 		userMessage.classList.add('mb-1', 'user-message');
 		userMessage.innerHTML = `<p class="text-primary-emphasis"><i class="bi bi-person-fill"></i> <strong>User</strong></p><pre>${escapeHtml(message)}</pre>`;
-		chatBox.appendChild(userMessage);
-    fetch('/image_chat/send_message', {
+		const selectedOption = document.querySelector('input[name="chat-option"]:checked').value;
+		const postUrl = selectedOption === 'gpt-3-5' ? '/image_chat/send_message/gpt-3-5' : '/image_chat/send_message/gpt-4';
+    fetch(postUrl, {
         method: 'POST',
         body: formData
     })
-    .then(response => response.json())
+    .then(response => {
+			if (!response.ok) {
+				throw new Error('Failed to send message because of not implemented yet.');
+			}
+		})
 		.then(data => {
 			const botMessage = document.createElement('div');
 			botMessage.classList.add('mb-1', 'bot-message');
@@ -135,7 +140,7 @@
 			chatBox.scrollTop = chatBox.scrollHeight;
 
 		}, (error) => {
-			console.log(error);
+			alert("Error: " + error.message);
 		});
 	});
 </script>

--- a/flask_app/templates/image_chat.list.html
+++ b/flask_app/templates/image_chat.list.html
@@ -18,7 +18,7 @@
 	<div class="chat-form-container text-center w-100 flex-grow-1 d-flex flex-column justify-content-end">
 		<div class="d-flex mb-3 align-items-center justify-content-center" style="width: 90%;">
 						<div style="width: 10%;">
-							<a href="{{ url_for('image_chat.chat') }}" class="btn btn-secondary mr-2" ><i class="bi bi-arrow-left"></i> Back</a>
+							<a href="{{ url_for('image_chat.chat') }}" class="btn btn-secondary me-4 btn-sm" ><i class="bi bi-arrow-left"></i> Back</a>
 						</div>
 						<div class="input-group" style="width: 70%;">
 							<input type="file" id="image-input" accept="image/*" class="form-control">

--- a/flask_app/templates/judge_fairness_chat.index.html
+++ b/flask_app/templates/judge_fairness_chat.index.html
@@ -7,16 +7,25 @@
 			<!-- chat will be displayed here -->
 	</div>
 	<div class="chat-form-container text-center w-100 flex-grow-1 d-flex flex-column justify-content-end">
-		<form id="chat-form" class="input-group mb-4" style="width: 70%; margin-left: 20vw;">
-			<label class="input-group-text" for="pdf-input">
-				<i class="bi bi-filetype-pdf"></i>
-			</label>
-			<input type="file" id="pdf-input" accept="application/pdf" class="form-control" style="display: none;">
-			<textarea id="chat-input" class="form-control" placeholder="Type a message..." rows="1"></textarea>
-			<button type="submit" class="btn btn-dark">
-				<i class="bi bi-send-fill"></i>
-			</button>
-		</form>
+		<div class="d-flex justify-content-between align-items-end w-100" >
+			<form id="chat-form" class="input-group mb-4" style="width: 60%; margin-left: 20vw;">
+				<label class="input-group-text" for="pdf-input">
+					<i class="bi bi-filetype-pdf"></i>
+				</label>
+				<input type="file" id="pdf-input" accept="application/pdf" class="form-control" style="display: none;">
+				<textarea id="chat-input" class="form-control" placeholder="Type a message..." rows="1"></textarea>
+				<button type="submit" class="btn btn-dark">
+					<i class="bi bi-send-fill"></i>
+				</button>
+			</form>
+		</div>
+		<div class="btn-group chat-options ms-auto me-4 mb-4 fixed-bottom " role="group" aria-label="gpt" style="width: 10%;">
+			<input type="radio" class="btn-check" name="chat-option" value="gpt-3-5" id="btnradio1" autocomplete="off" checked>
+			<label class="btn btn-outline-primary" for="btnradio1">GPT-3.5</label>
+
+			<input type="radio" class="btn-check" name="chat-option" value="/gpt-4" id="btnradio2" autocomplete="off">
+			<label class="btn btn-outline-primary" for="btnradio2">GPT-4</label>
+		</div>
 		<div class="chat-instructions text-center w-50 mx-auto mb-1 fixed-bottom">
 				Shift + Enter or Click button to send a message
 		</div>

--- a/flask_app/templates/judge_fairness_chat.index.html
+++ b/flask_app/templates/judge_fairness_chat.index.html
@@ -134,7 +134,9 @@
 			userMessage.innerHTML = `<p class="text-primary-emphasis"><i class="bi bi-person-fill"></i> <strong>User</strong></p><pre>${escapeHtml(message)}</pre>`;
 		}
 		chatBox.appendChild(userMessage);
-    fetch('/judge_fairness_chat/send_message', {
+		const selectedOption = document.querySelector('input[name="chat-option"]:checked').value;
+		const postUrl = selectedOption === 'gpt-3-5' ? '/judge_fairness_chat/send_message/gpt-3-5' : '/judge_fairness_chat/send_message/gpt-4';
+    fetch(postUrl, {
         method: 'POST',
         body: formData
     })

--- a/flask_app/views/feedback.py
+++ b/flask_app/views/feedback.py
@@ -6,7 +6,12 @@ feedback_bp = Blueprint('feedback', __name__)
 def feedback():
     return render_template('feedback.index.html')
 
-@feedback_bp.route('/feedback/send_message', methods=['POST'])
-def send_message():
+@feedback_bp.route('/feedback/send_message/gpt-3-5', methods=['POST'])
+def send_message_3_5():
     user_message = request.form.get('message')
-    return "Feedback function is not implemented yet."
+    return "Feedback GPT3.5 function is not implemented yet."
+
+@feedback_bp.route('/feedback/send_message/gpt-4', methods=['POST'])
+def send_message_4():
+    user_message = request.form.get('message')
+    return "Feedback GPT 4 function is not implemented yet."

--- a/flask_app/views/image_chat.py
+++ b/flask_app/views/image_chat.py
@@ -88,8 +88,12 @@ def upload_image():
         return redirect(url_for('image_chat.list'))
     return redirect(request.url)
 
-@image_chat_bp.route('/image_chat/send_message', methods=['POST'])
-def send_message():
+@image_chat_bp.route('/image_chat/send_message/gpt-4', methods=['POST'])
+def send_message_4():
+    return jsonify({"error": "Image Chat GPT4 function is not implemented yet."}), 400
+
+@image_chat_bp.route('/image_chat/send_message/gpt-3-5', methods=['POST'])
+def send_message_3_5():
     ###ひとまずデータベースから与えられた単語に一致するデータを拾ってくる。
     ###user_messageは本来単語じゃないのでGPTを使って単語のリストに処理する必要がある。
     user_message = request.form.get('message')

--- a/flask_app/views/judge_fairness_chat.py
+++ b/flask_app/views/judge_fairness_chat.py
@@ -10,8 +10,12 @@ judge_fairness_chat_bp = Blueprint('judge_fairness_chat', __name__)
 def chat():
     return render_template('judge_fairness_chat.index.html')
 
-@judge_fairness_chat_bp.route('/judge_fairness_chat/send_message', methods=['POST'])
-def send_message():
+@judge_fairness_chat_bp.route('/judge_fairness_chat/send_message/gpt-4', methods=['POST'])
+def send_message_4():
+    return "Judge Fairness GPT4 function is not implemented yet."
+
+@judge_fairness_chat_bp.route('/judge_fairness_chat/send_message/gpt-3-5', methods=['POST'])
+def send_message_3_5():
     # user_messageかpdf_fileどちらかは必須で入る。
     # pdfがない場合user_messageをtextとして使う, ２つ入力がある場合はpdfを優先する
     user_message = request.form.get('message')


### PR DESCRIPTION
### 実装したこと
- gpt3-5, 4の選択ボタンを追加
- 選択した状態によって実行するレスポンスの関数も分けといた
- .pyファイル側でモデル違いの２つほぼ同じ関数用意すればOK
- 分けたからモデルによって、ちょっと処理変えたりもできる

確認したらマージして大丈夫

<img width="1680" alt="スクリーンショット 2024-01-20 12 48 13" src="https://github.com/ryhara/Azure_OpenAI_Service_Hackathon/assets/89718149/afa4b80f-61f9-450b-87f4-29a0b0f3fbb1">

<img width="1680" alt="スクリーンショット 2024-01-20 12 48 22" src="https://github.com/ryhara/Azure_OpenAI_Service_Hackathon/assets/89718149/2dc726a3-6777-4004-b7ac-872c698ab54e">


